### PR TITLE
Rotation in drawing scene is solved.

### DIFF
--- a/src/scenes/eyePlotter/strokes/strokeUtils.h
+++ b/src/scenes/eyePlotter/strokes/strokeUtils.h
@@ -137,8 +137,8 @@ class strokeUtils{
 
 		ofRectangle rect = strokeUtils::getBoundingRectFromGroups(strokeGroups);
 
-		ofPoint mid(rect.x + rect.width/2, rect.y + rect.height/2);
-		ofPoint tmp;
+		ofVec2f mid(rect.x + rect.width/2, rect.y + rect.height/2);
+		ofVec2f tmp;
 
 		for(int j = 0; j < strokeGroups.size(); j++){
 


### PR DESCRIPTION
Description of issue #12 :
Reason: The points in letter were being taken as 3D points in "strokeUtils.h".
Fix: Used "ofVec2f" in place of "ofPoint" in "strokeUtils.h"
fixes #12